### PR TITLE
Adicionando endpoint que verifica se nome de usuário solicitado está disponível para uso

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ quote-style = 'single'
 "settings.py" = ['D103', 'D101', 'D100']
 "db.py" = ['D100']
 "hasher.py" = ['D100']
+"online_users.py" = ['D100']
 
 [tool.taskipy.tasks]
 run = 'uvicorn --reload --host 127.0.0.1 server.main:app'

--- a/server/main.py
+++ b/server/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from server.db import redis_client
-from server.routers import status, ws
+from server.routers import online_users, status, ws
 
 description = """
 Este servidor realiza o encaminhamento de mensagens entre usuários conectados
@@ -49,3 +49,4 @@ app = FastAPI(
 
 app.include_router(ws.router)
 app.include_router(status.router)
+app.include_router(online_users.router)

--- a/server/routers/online_users.py
+++ b/server/routers/online_users.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException, status
+
+from server.db import redis_client
+from server.hasher import hash_id
+from server.schemas.message import Message
+
+router = APIRouter(prefix='/online-users', tags=['Online Users'])
+
+
+@router.get(
+    '/{user_id}',
+    response_model=Message,
+    summary='Verifica se o nome de usuário solicitado está disponível.',
+)
+async def check_username_availability(user_id: str):
+    """
+    Verifica a disponibilidade de um nome de usuário no sistema.
+
+    Este endpoint consulta o banco de dados Redis para determinar se o usuário
+    especificado já está registrado como "online". Caso o usuário esteja em uso,
+    a API retorna um erro de conflito (HTTP 409). Caso contrário, confirma que
+    o nome está disponível.
+
+    Args:
+        user_id (str): O identificador único do usuário que se deseja verificar.
+
+    Raises:
+        HTTPException: Retorna um erro 409 (Conflict) se o nome de usuário já
+        estiver em uso no momento.
+
+    Returns:
+        Message: Um objeto contendo uma mensagem informando que o nome de usuário
+        está disponível.
+
+    """
+    is_online = await redis_client.sismember('online_users', hash_id(user_id))
+
+    if is_online:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail='Este nome de usuário não está disponível'
+        )
+
+    return {'message': 'O nome de usuário está disponível'}

--- a/server/schemas/message.py
+++ b/server/schemas/message.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class Message(BaseModel):
+    message: str


### PR DESCRIPTION
Este PR adiciona um simples endpoint que verifica se um determinado username está disponível para uso, ou seja, se ninguém já está usando ele.

Caso alguém já esteja usando o username esse endpoint irá retornar um status code 409, caso contrário, retornará 200.